### PR TITLE
Rate limit

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,46 @@
 
 This module acts as a multiplexer and cache for the [trusted external data](https://tickets.puppetlabs.com/browse/PUP-9994) feature of Puppet. This module execute "foragers" to gather data and stores it in a cache, both of which are pluggable
 
-## Foragers
+## Using This Module
+
+In order to enable this integration, classify all Masters and Compilers with the `external_data` class and then configure:
+
+* **The cache:** This will be used to store data, the recommended cache is `disk` which caches data to a directory on the local filesystem
+* **The Foragers:** This module doesn't contain any foragers, you will have to get those from other modules that are designed to work with this one. You can have as many forager as you like and they will be executed as required to gather external data about your nodes
+
+```puppet
+class { 'external_data':
+  config => {
+    'cache'    => {
+      'name'    => 'disk',
+      'options' => {
+        'path' => '/opt/puppetlabs/cache', # Remeber to create this directory
+      },
+    },
+    'foragers' => [
+      {
+        'name'    => 'example',
+        'options' => {
+          'colour' => 'red',
+        }
+      }
+    ]
+  },
+  notify => Service['pe-puppetserver'],
+}
+```
+
+## Caches
+
+### Disk
+
+This uses the local disk to store cached data in JSON files under a given directory, it is the simplest form of cache and is fairly performant, but lacks any form of synchronisation meaning that if you have many compilers or masters, each will maintain its own cache, increasing the workload for whatever the foragers are hiting.
+
+#### Options
+
+`path`: The path on disk where files should be stored. This needs to exist and should be writable by the user which the puppetserver runs as.
+
+## Writing Foragers
 
 Foragers are the most interesting part of this module, they are used for getting information about nodes from external sources, the following types of foragers are available:
 

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ class { 'external_data':
 
 ### `disk`
 
-This uses the local disk to store cached data in JSON files under a given directory, it is the simplest form of cache and is fairly performant, but lacks any form of synchronisation meaning that if you have many compilers or masters, each will maintain its own cache, increasing the workload for whatever the foragers are hiting.
+This uses the local disk to store cached data in JSON files under a given directory, it is the simplest form of cache and is fairly performant, but lacks any form of synchronization meaning that if you have many compilers or masters, each will maintain its own cache, increasing the workload for whatever the foragers are hitting.
 
 #### Options
 
@@ -49,25 +49,33 @@ This simply doesn't cache. Any foragers that are designed to use a cache, won't.
 
 This cache has no options.
 
+## Foragers
+
+There are some options that apply to all foragers:
+
+`min_age`: The minimum age for a record in seconds, if records are older younger than this the forager will not be executed at all and the cache will be used.
+
 ## Writing Foragers
 
-Foragers are the most interesting part of this module, they are used for getting information about nodes from external sources, the following types of foragers are available:
+[Example Forager](https://github.com/dylanratcliffe/puppet-external_data/blob/master/lib/puppet_x/external_data/forager/example.rb)
 
-### `:ondemand`
+Foragers are the most interesting part of this module, they are used for getting information about nodes from external sources, the following types of foragers are available
 
-On Demand foragers execute each time the catalog is compiled for a particular host. They do no caching and should only be used when a very high performance backend is in place
+### Types
 
-### `:ondemand_cached`
+#### `:ondemand`
+
+On Demand foragers execute each time the catalog is compiled for a particular host. This assumes that the API we are interacting with doesn't have any way of checking for records that have been updated since a certain time. If combined with `min_age` this allows for a very simple way of creating integrations as each record will be cached until it reaches its `min_age`, then it will be looked up the next time the node checks in., the cache will be used in the meantime. If `min_age` is not set then these won't be cached at all.
+
+#### `:ondemand_cached`
 
 Similar to an `:ondemand` forager except that it is able to receive an empty response from whatever this is querying and treat this as "The data has not changed" in which case the previous data for that node will be returned. These backends will also need to be able to receive a response that means "There is no data here" in which case the cache for that node will need to be cleared and nothing returned to the puppetserver
 
-### `:batch`
+#### `:batch`
 
 Batch foragers will always return cached data on catalog compiles as they only do updates in batches. **This has yet to be implemented**
 
-### Writing Foragers
-
-[Example Forager](https://github.com/dylanratcliffe/puppet-external_data/blob/master/lib/puppet_x/external_data/forager/example.rb)
+### Required Methods
 
 Foragers must implement the following methods:
 

--- a/README.md
+++ b/README.md
@@ -33,13 +33,21 @@ class { 'external_data':
 
 ## Caches
 
-### Disk
+### `disk`
 
 This uses the local disk to store cached data in JSON files under a given directory, it is the simplest form of cache and is fairly performant, but lacks any form of synchronisation meaning that if you have many compilers or masters, each will maintain its own cache, increasing the workload for whatever the foragers are hiting.
 
 #### Options
 
 `path`: The path on disk where files should be stored. This needs to exist and should be writable by the user which the puppetserver runs as.
+
+### `none`
+
+This simply doesn't cache. Any foragers that are designed to use a cache, won't. Any `:batch` foragers will not be able to store their data anywhere and will therefore not work. This was only really created for testing and I can't imagine many uses for it.
+
+#### Options
+
+This cache has no options.
 
 ## Writing Foragers
 

--- a/lib/puppet_x/external_data/forager.rb
+++ b/lib/puppet_x/external_data/forager.rb
@@ -43,7 +43,7 @@ module Puppet_X # rubocop:disable Style/ClassAndModuleCamelCase,Style/ClassAndMo
         @cache = opts[:cache]
 
         # Default min_age to false
-        @min_age = opts[:min_age] ? opts[:min_age].to_i : false
+        @min_age = opts[:min_age] ? opts[:min_age].to_i : false # rubocop:disable Style/TernaryParentheses
 
         # Create logging config
         @logger       = opts[:logger] || Logger.new(STDERR)

--- a/lib/puppet_x/external_data/forager.rb
+++ b/lib/puppet_x/external_data/forager.rb
@@ -33,6 +33,7 @@ module Puppet_X # rubocop:disable Style/ClassAndModuleCamelCase,Style/ClassAndMo
       attr_reader :cache
       attr_reader :logger
       attr_reader :metadata
+      attr_reader :min_age
 
       def initialize(opts = {})
         # Perform validation
@@ -40,6 +41,9 @@ module Puppet_X # rubocop:disable Style/ClassAndModuleCamelCase,Style/ClassAndMo
 
         raise ':cache option must be specified' unless opts[:cache]
         @cache = opts[:cache]
+
+        # Default min_age to false
+        @min_age = opts[:min_age] ? opts[:min_age].to_i : false
 
         # Create logging config
         @logger       = opts[:logger] || Logger.new(STDERR)
@@ -50,33 +54,58 @@ module Puppet_X # rubocop:disable Style/ClassAndModuleCamelCase,Style/ClassAndMo
       # return the data for a given node. Mostly it is responsible for calling
       # out to the appropriate methods to actually go and get the data.
       def data_for(certname)
-        logger.info("Finding data for #{certname} using forager #{name}")
+        logger.info("#{name}: Finding data for #{certname}")
+
+        # Only run this if we are using the feature, this will reduce load on
+        # the metadata
+        if min_age
+          # Check the minimum age. This allows simpler foragers to retrieve
+          # information for a node every x seconds, as needed. This will be
+          # useful for APIs that don't have an "updated since" feature
+          last_run = metadata["#{certname}-last_run"].to_i
+          now      = Time.now.to_i
+          if (now - last_run) < min_age
+            logger.info("#{name}: #{certname} not older than min_age, using cache")
+            return cache.get(name, certname)
+          else
+            metadata["#{certname}-last_run"] = now
+          end
+        end
 
         case type
         when :ondemand
-          get_data(certname)
+          data = get_data(certname)
+
+          # Only bother caching the data if there is a minimum age set,
+          # otherwise the cache will never be used and there is no point
+          if min_age != false
+            logger.info("#{name}: #{certname} updated, persisting to cache")
+            cache.update(name, certname, data)
+          end
+
+          return data
         when :ondemand_cached
           # Get the data
           data = get_data(certname)
 
           case data
           when nil
-            logger.info("#{certname} not updated, using cache")
+            logger.info("#{name}: #{certname} not updated, using cache")
 
             # This means that nothing has changed and we should use the cache
             return cache.get(name, certname)
           when {}
-            logger.info("#{certname} deleted, deleting cached data")
+            logger.info("#{name}: #{certname} deleted, deleting cached data")
 
             # When an empty hash is returned it means that we need to delete the
             # cached data and return nothing
             cache.delete(name, certname)
-            logger.info("#{certname} deleted form cache")
+            logger.info("#{name}: #{certname} deleted form cache")
             return nil
           else
-            logger.info("#{certname} updated, persisting to cache")
+            logger.info("#{name}: #{certname} updated, persisting to cache")
             cache.update(name, certname, data)
-            logger.info("#{certname} saved to cache")
+            logger.info("#{name}: #{certname} saved to cache")
             return data
           end
         when :batch

--- a/lib/puppet_x/external_data/forager/example.rb
+++ b/lib/puppet_x/external_data/forager/example.rb
@@ -7,6 +7,9 @@ module Puppet_X::ExternalData # rubocop:disable Style/ClassAndModuleCamelCase
     def initialize(opts)
       @data = nil
       @colour = opts[:colour] || 'not specified'
+      # Since this is only used for testing it's good to be able to change the
+      # way it works
+      @type   = opts[:type] || :ondemand_cached
 
       raise 'colour must be a string' unless @colour.is_a? String
 
@@ -14,13 +17,17 @@ module Puppet_X::ExternalData # rubocop:disable Style/ClassAndModuleCamelCase
     end
 
     def type
-      :ondemand_cached
+      # Usually this swould just be static i.e.
+      # :ondemand
+      @type.to_sym
     end
 
     def get_data(certname)
       # If this has been called before then return that it hasn't changed
-      return nil if metadata["#{certname}-updated"]
-      metadata["#{certname}-updated"] = true
+      if type == :ondemand_cached
+        return nil if metadata["#{certname}-updated"]
+        metadata["#{certname}-updated"] = true
+      end
 
       raise 'certname must not be blank' if certname.empty?
 

--- a/lib/puppet_x/external_data/metadata.rb
+++ b/lib/puppet_x/external_data/metadata.rb
@@ -16,6 +16,8 @@ module Puppet_X # rubocop:disable Style/ClassAndModuleCamelCase,Style/ClassAndMo
       end
 
       def []=(k, v)
+        raise 'Metadata keys must be strings' unless k.is_a? String
+
         if v.nil?
           @cache.delete(@forager, "metadata-#{k}")
         else

--- a/spec/fixtures/configs/min_age.yaml
+++ b/spec/fixtures/configs/min_age.yaml
@@ -1,0 +1,10 @@
+---
+cache:
+  name: none
+  options: {}
+foragers:
+  - name: example
+    options:
+      min_age: 2
+      type: ondemand
+      colour: black


### PR DESCRIPTION
This substantially improves the usefulness of `:ondemand` foragers since they can now have a `min_age` setting which means that you can essentially rate-limite them and have a method caching, if a bit dumber than `:ondemand_cached`